### PR TITLE
Fix Bootstrap Bundle link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,7 @@
 
     {%- include footer.html -%}
 
-    <script src="/assets/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ '/assets/js/bootstrap.bundle.min.js' | relative_url }}"></script>
   </body>
 
 </html>


### PR DESCRIPTION
The Bootstrap Bundle link needs to be a relative url, for cases such as a github pages site not using a custom URL or any site not served from the root.